### PR TITLE
state was being built with filenames without the path

### DIFF
--- a/lib/ocflObject-filesystem-backend.spec.js
+++ b/lib/ocflObject-filesystem-backend.spec.js
@@ -564,7 +564,7 @@ describe("Testing object manipulation functionality - object with one version", 
 
     let version = await object.getLatestVersion();
 
-    let file = version.state["file_0.txt"].pop();
+    let file = version.state["sample/file_0.txt"].pop();
     file = object.resolveFilePath({ filePath: file.path });
     expect(file).toMatch(/v1\/content\/sample\/file_0.txt/);
   });

--- a/lib/ocflObject-s3-backend.spec.js
+++ b/lib/ocflObject-s3-backend.spec.js
@@ -672,7 +672,7 @@ describe("Testing object manipulation functionality - object with one version", 
 
     let version = await object.getLatestVersion();
 
-    let file = version.state["file_0.txt"].pop();
+    let file = version.state["sample/file_0.txt"].pop();
     file = object.resolveFilePath({ filePath: file.path });
     expect(file).toMatch(/v1\/content\/sample\/file_0.txt/);
     await object.bucket.removeObjects({ prefix: id });

--- a/lib/ocflObject.js
+++ b/lib/ocflObject.js
@@ -236,7 +236,7 @@ class OcflObject {
       files.push(
         items.map((item) => {
           return {
-            name: item.split("/").pop(),
+            name: item.replace(/^v\d+\/content\//, ''),
             path: item,
             hash,
             version: parseInt(item.split("/").shift().replace("v", "")),


### PR DESCRIPTION
Our fix is evil. We should use a lookup in the object manifest?

Note: Did not run tests